### PR TITLE
Loading examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The `redis_loader` service supports two modes of loading data: command-line and 
 In command-line mode, arguments are passed directly to the `redis_loader` service.
 For example:
 ```console
-docker compose -f compose.yml -f compose.prod.yml run redis_loader --load_type reload \
+docker compose -f compose.yml -f compose.prod.yml run redis_loader \
     gff \
         --genus Glycine \
         --species max \
@@ -108,7 +108,7 @@ The `redis_loader` service is actually a Python module.
 The scripts in the `redis_loader` container's `/docker-entrypoint-initdb.d/` directory can run this python module directly.
 For example, the `data/docker-entrypoint-initdb.d/example.sh` script used in the [Quick Start](#quick-start) runs the example from the [Command-line](#command-line) section:
 ```console
-python -u -m redis_loader --load_type reload \
+python -u -m redis_loader \
     gff \
         --genus Glycine \
         --species max \

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -63,4 +63,4 @@ services:
       - "traefik.zone=${COMPOSE_PROJECT_NAME}"
 
   redis_loader:
-    image: ghcr.io/legumeinfo/microservices-redis_loader:1.2.3
+    image: ghcr.io/legumeinfo/microservices-redis_loader:1.3.0

--- a/data/docker-entrypoint-initdb.d/example.sh
+++ b/data/docker-entrypoint-initdb.d/example.sh
@@ -2,7 +2,8 @@
 
 set -o errexit -o pipefail
 
-python -u -m redis_loader --load_type reload \
+# NOTE: --load-type isn't necessary because this script will only run if the Redis database is empty
+python -u -m redis_loader \
     gff \
        --genus Glycine \
        --species max \


### PR DESCRIPTION
This PR drops the `--load-type` flag from the `data/docker-entrypoint-initdb.d/example.sh` script and from `README.md`. It also pulls in the latest version of the redis_loader microservice, which changes the default value of the `--load-type` flag from `append` to `new` and updates the Docker image's `entrypoint.sh` script to only execute `*.sh` scripts in the container's `/docker-entrypoint-initdb.d/` directory if the Redis database is empty AND no command-line arguments are provided.